### PR TITLE
feat: Save/restore machine-id file for insights-client

### DIFF
--- a/pytest_client_tools/insights_client.py
+++ b/pytest_client_tools/insights_client.py
@@ -46,6 +46,10 @@ INSIGHTS_CLIENT_FILES_TO_SAVE = (
         pathlib.Path("/var/log/insights-client/insights-client-payload.log.3"),
         remove_at_start=True,
     ),
+    SavedFile(
+        pathlib.Path("/etc/insights-client/machine-id"),
+        remove_at_start=True,
+    ),
 )
 
 


### PR DESCRIPTION
Save and restore machine-id file for insights-client. This would ensure that this file will not be created before launching the integration tests for insights-client.

---
This change was necessary because the update in [insights-core#4388](https://github.com/RedHatInsights/insights-core/pull/4388) caused integration test failures.