### PR TITLE
fix: Save yggdrasil config.toml on RHEL10+

### DIFF
--- a/pytest_client_tools/rhc.py
+++ b/pytest_client_tools/rhc.py
@@ -12,6 +12,7 @@ from .util import SavedFile, logged_run, Version, redact_arguments
 RHC_FILES_TO_SAVE = (
     SavedFile(pathlib.Path("/etc/rhc/config.toml")),
     SavedFile(pathlib.Path("/etc/rhc/workers/rhc-package-manager.toml")),
+    SavedFile(pathlib.Path("/etc/yggdrasil/config.toml")),
 )
 
 


### PR DESCRIPTION
Updated code to save /etc/yggdrasil/config.toml for RHEL 10+ systems.
on RHEL9 and below /etc/rhc/config.toml exists.