### PR TITLE
fix: Add support for development Core

### DIFF
--- a/pytest_client_tools/insights_client.py
+++ b/pytest_client_tools/insights_client.py
@@ -244,7 +244,7 @@ class InsightsClient:
         :rtype: pytest_client_tools.util.Version
         """
         proc = self.run("--version")
-        m = re.search(r"^Core: (.+)-\d+$", proc.stdout, re.MULTILINE)
+        m = re.search(r"^Core: (.+)-(\d+|dev)$", proc.stdout, re.MULTILINE)
         assert m
         return Version(m.group(1))
 


### PR DESCRIPTION
Development (upstream) version of Insights Core reports version of 'Core: 3.0.8-dev'. The updated regex reflects that.