### PR TITLE
Specify complete SELinux context

### DIFF
--- a/pytest_client_tools/insights_client.py
+++ b/pytest_client_tools/insights_client.py
@@ -283,7 +283,7 @@ class InsightsClient:
         *args,
         check=True,
         text=True,
-        selinux_context="system_u:system_r:insights_client_t",
+        selinux_context="system_u:system_r:insights_client_t:s0",
     ):
         """
         Run `insights-client` with the specified arguments.


### PR DESCRIPTION
It was missing level. Use "s0" which is in targeted the only level used. For more information see:
https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/security-enhanced_linux/chap-security-enhanced_linux-selinux_contexts